### PR TITLE
fix getColumnList() method in AbstractMatrix.java

### DIFF
--- a/ujmp-core/src/main/java/org/ujmp/core/AbstractMatrix.java
+++ b/ujmp-core/src/main/java/org/ujmp/core/AbstractMatrix.java
@@ -262,7 +262,7 @@ public abstract class AbstractMatrix extends Number implements Matrix {
 		// not quite optimized
 		List<Matrix> list = new FastArrayList<Matrix>();
 		for (int c = 0; c < getColumnCount(); c++) {
-			list.add(selectRows(Ret.LINK, c));
+			list.add(selectColumns(Ret.LINK, c));
 		}
 		return list;
 	}


### PR DESCRIPTION
I really love your project while I found a small issue when using it. The getColumnLIst() method in AbstractMatrix class was providing rows instead of columns (but length of columns). I try to fix this small issue.